### PR TITLE
Integrate MAGMA v2.9.0 from GitHub repository

### DIFF
--- a/cmake/ImportMAGMA.cmake
+++ b/cmake/ImportMAGMA.cmake
@@ -18,20 +18,48 @@ set(tag "v2.9.0")
 # 'version' specifies the version of the MAGMA library.
 set(version "2.9.0")
 # 'flag' is intended for additional configuration options during the build process.
-set(flag "-DGPU_TARGET=Ampere")
+set(flag "-DGPU_TARGET=Volta")
 # 'is_cmake' indicates that MAGMA uses CMake for its build system, which is set to ON.
 set(is_cmake ON)
-# 'is_git' - Using tarball (OFF) instead of git because git requires running 'make generate' first
-set(is_git OFF)
+# 'is_git' - Using GitHub repository
+set(is_git ON)
 # 'auto_gen' signals whether autogen scripts are required for the build process.
 set(auto_gen OFF)
- # 'url' provides the location of the MAGMA source tarball (v2.9.0 release).
-set(url "https://icl.utk.edu/projectsfiles/magma/downloads/magma-2.9.0.tar.gz")
+ # 'url' provides the location of the MAGMA GitHub repository.
+set(url "https://github.com/icl-utk-edu/magma.git")
 
-# The 'ImportDependency' macro script, located in the 'macros' directory, is included for managing the import and setup of the MAGMA library.
+# Define MAGMA-specific hooks for BuildDependency
+
+# Pre-build: Generate CMake files for git builds
+macro(MAGMA_PreBuild srcpath flags)
+    message(STATUS "MAGMA: Running make generate for git build")
+    string(REGEX MATCH "GPU_TARGET=([A-Za-z0-9_,]+)" _ "${flags}")
+    set(gpu "${CMAKE_MATCH_1}")
+    if(NOT gpu)
+        set(gpu "Volta")
+    endif()
+    file(WRITE "${srcpath}/make.inc" "BACKEND = cuda\nFORT = true\nGPU_TARGET = ${gpu}\n")
+    execute_process(COMMAND make generate WORKING_DIRECTORY ${srcpath} 
+        RESULT_VARIABLE result OUTPUT_QUIET ERROR_QUIET)
+    if(result)
+        message(FATAL_ERROR "MAGMA make generate failed")
+    endif()
+endmacro()
+
+# Post-build: Fix version in pkgconfig file
+macro(MAGMA_PostBuild installpath tag)
+    set(pc "${installpath}/lib/pkgconfig/magma.pc")
+    if(EXISTS "${pc}")
+        string(REPLACE "v" "" ver "${tag}")
+        file(READ "${pc}" content)
+        string(REPLACE "Version: 0.0.0" "Version: ${ver}" content "${content}")
+        file(WRITE "${pc}" "${content}")
+        message(STATUS "MAGMA: Fixed pkgconfig version to ${ver}")
+    endif()
+endmacro()
+
+# Use standard ImportDependency (will call our hooks automatically)
 include(macros/ImportDependency)
-# The 'ImportDependency' macro is invoked with the above-defined parameters to handle the detection, fetching, and integration of MAGMA into the project.
 ImportDependency(${name} ${tag} ${version} ${url} "${flag}" "" ${is_cmake} ${is_git} ${auto_gen})
 
-# A status message is outputted to indicate the successful integration of the MAGMA library into the project.
 message(STATUS "${name} done")

--- a/cmake/macros/BuildDependency.cmake
+++ b/cmake/macros/BuildDependency.cmake
@@ -83,6 +83,13 @@ macro(BuildDependency raw_name url tag flags is_using_cmake is_using_git auto_ge
         endif()
     endforeach()
 
+    # Optional pre-build hook (if defined by caller)
+    if(${capital_name} STREQUAL "MAGMA")
+        if(COMMAND MAGMA_PreBuild)
+            MAGMA_PreBuild(${${name}_srcpath} "${flags}")
+        endif()
+    endif()
+
     # Configure the project. If using CMake, run cmake command with specified flags and install prefix within the binary path.
     if (${is_using_cmake})
         execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}/${capital_name} -DCMAKE_C_FLAGS=-fPIC -DCMAKE_CXX_FLAGS=-fPIC -DCMAKE_CUDA_FLAGS=-fPIC -DCMAKE_Fortran_COMPILER=gfortran ${flags}
@@ -120,6 +127,13 @@ macro(BuildDependency raw_name url tag flags is_using_cmake is_using_git auto_ge
                 WORKING_DIRECTORY ${${name}_srcpath}
                 COMMAND_ERROR_IS_FATAL ANY)  # Halt on error
     endif ()
+
+    # Optional post-build hook (if defined by caller)
+    if(${capital_name} STREQUAL "MAGMA")
+        if(COMMAND MAGMA_PostBuild)
+            MAGMA_PostBuild(${${name}_installpath} "${tag}")
+        endif()
+    endif()
 
     # Set environment variables for dynamic and static linking as well as include paths, pointing to the dependency's installation directory.
     set(ENV{LD_LIBRARY_PATH} "${${name}_installpath}/lib:${${name}_installpath}/lib64:$ENV{LD_LIBRARY_PATH}")


### PR DESCRIPTION
- Switch from tarball to GitHub repository for MAGMA
- Add pre-build hook to run 'make generate' for git builds
- Add post-build hook to fix pkgconfig version
- Extend BuildDependency with optional hook support for MAGMA"